### PR TITLE
update service-connector mismatch check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fuseki YAML Config Parser
+## 1.0.3
+- Update connector-service mismatch checks
+
 ## 1.0.2
+- Add fk:configFile field to connectors
+
+## 1.0.1
 - Minor improvements to build
 
 ## 1.0.0

--- a/src/main/java/yamlconfig/ConfigStruct.java
+++ b/src/main/java/yamlconfig/ConfigStruct.java
@@ -152,7 +152,35 @@ public class ConfigStruct {
                 }
             }
             for (String service : servicesFromConnectors) {
-                if (!servicesFromServices.contains(service))
+                if (checkForServicesMismatchWithEndpoints(servicesFromServices, service))
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean checkForServicesMismatchWithEndpoints(Set<String> servicesFromServices, String connectorService) {
+        if (servicesFromServices.contains(connectorService))
+            return false;
+        try {
+            String serviceName = "/" + connectorService.split("/")[1];
+            String endpoint = connectorService.split("/")[2];
+        }
+        catch (RuntimeException ex) {
+            log.error(ex.getMessage());
+            return true;
+        }
+        if (servicesFromServices.contains("/" + connectorService.split("/")[1])) {
+            Service theService = this.services.stream()
+                    .filter(service -> service.name().equals(connectorService.split("/")[1]))
+                    .findFirst()
+                    .orElse(null);
+            if (theService != null) {
+                Endpoint theEndpoint = theService.endpoints().stream()
+                        .filter(endpoint -> endpoint.name().equals(connectorService.split("/")[2]))
+                        .findFirst()
+                        .orElse(null);
+                if (theEndpoint != null)
                     return false;
             }
         }

--- a/src/test/files/rdf/abac/config-test-abac-1.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-1.ttl
@@ -12,6 +12,11 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
                     ];
         ja:data     "src/main/files/abac/data-and-labels.trig" .
 
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .
+
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :abac-mem-db;
         fuseki:endpoint  [ fuseki:name       "upload";
@@ -24,8 +29,3 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         authz:attributes  <file:abac/attribute-store.ttl>;
         authz:cache       false;
         authz:dataset     :dataset-under .
-
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .

--- a/src/test/files/rdf/abac/config-test-abac-2.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-2.ttl
@@ -16,6 +16,11 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
 :dataset-under  rdf:type  tdb2:DatasetTDB2;
         tdb2:location  "target/test-abac-DB" .
 
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .
+
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :abac-tdb2-db;
         fuseki:endpoint  [ fuseki:name       "upload";
@@ -23,8 +28,3 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
                          ];
         fuseki:endpoint  [ fuseki:operation  fuseki:query ];
         fuseki:name      "ds" .
-
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .

--- a/src/test/files/rdf/abac/config-test-abac-3.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-3.ttl
@@ -6,6 +6,11 @@ PREFIX ja:     <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
 
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .
+
 :dataset-under  rdf:type  ja:MemoryDataset;
         ja:data   "src/main/files/abac/data-and-labels.trig" .
 
@@ -13,11 +18,6 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         authz:attributesURL  "http://localhost:3133/users/lookup/{user}";
         authz:cache          false;
         authz:dataset        :dataset-under .
-
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .
 
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :abac-db;

--- a/src/test/files/rdf/abac/config-test-abac-4.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-4.ttl
@@ -6,11 +6,6 @@ PREFIX ja:     <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
 
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .
-
 :dataset-under  rdf:type  ja:MemoryDataset;
         ja:data   "src/main/files/abac/data-and-labels.trig" .
 
@@ -26,3 +21,8 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
                          ];
         fuseki:endpoint  [ fuseki:operation  fuseki:query ];
         fuseki:name      "ds" .
+
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .

--- a/src/test/files/rdf/abac/config-test-abac-prefixes.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-prefixes.ttl
@@ -15,6 +15,11 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
         authz:labelsStore  [ authz:labelsStorePath
                           "target/labels" ] .
 
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .
+
 :dataset-under  rdf:type  tdb2:DatasetTDB2;
         tdb2:location  "target/test-abac-DB" .
 
@@ -28,8 +33,3 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
                            fuseki:operation  authz:upload
                          ];
         fuseki:name      "ds" .
-
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .

--- a/src/test/files/rdf/connector/config-connector-integration-test-1.ttl
+++ b/src/test/files/rdf/connector/config-connector-integration-test-1.ttl
@@ -26,12 +26,12 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         fuseki:endpoint  [ fuseki:operation  fuseki:query ];
         fuseki:name      "ds2" .
 
+:dataset  rdf:type  ja:MemoryDataset .
+
 [ rdf:type         fuseki:Server;
   fuseki:name      "Fuseki server simple";
   fuseki:services  ( :service1 :service2 )
 ] .
-
-:dataset  rdf:type  ja:MemoryDataset .
 
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :dataset;

--- a/src/test/files/rdf/connector2.ttl
+++ b/src/test/files/rdf/connector2.ttl
@@ -1,0 +1,28 @@
+PREFIX :       <http://testing.com/#>
+PREFIX authz:  <http://telicent.io/security#>
+PREFIX fk:     <http://jena.apache.org/fuseki/kafka#>
+PREFIX fuseki: <http://jena.apache.org/fuseki#>
+PREFIX ja:     <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
+
+:connector1
+        rdf:type              fk:Connector;
+        fk:bootstrapServers   "localhost:9092";
+        fk:config             ("key1" "value1");
+        fk:config             ("key2" "value2");
+        fk:fusekiServiceName  "/ds";
+        fk:groupId            "JenaFusekiKafka";
+        fk:replayTopic        true;
+        fk:stateFile          "dDatabases/RDF.state";
+        fk:topic              "env:{ENV_KAFKA_TOPIC:RDF}" .
+
+:connector2
+        rdf:type              fk:Connector;
+        fk:bootstrapServers   "localhost:9093";
+        fk:fusekiServiceName  "/ds2/data-update";
+        fk:groupId            "JenaFusekiKafka2";
+        fk:replayTopic        true;
+        fk:topic              "env:{ENV_KAFKA_TOPIC:RDF}";
+        fk:stateFile          "dDatabases/RDF.state" ;
+        fk:configFile         "env:{KAFKA_CONFIG_FILE_PATH:}".

--- a/src/test/files/yaml/correct/connector/config-multiple-connectors-2.yaml
+++ b/src/test/files/yaml/correct/connector/config-multiple-connectors-2.yaml
@@ -1,0 +1,49 @@
+version: "1.0"
+server:
+  name: "Fuseki server simple"
+services:
+  - name: "ds"
+    endpoints:
+      - name: "sparql"
+        operation: query
+        settings:
+          'arq:queryTimeout': "1000,10000"
+      - name: "data-update"
+        operation: update
+    database:  "tdb2-db"
+  - name: "ds2"
+    endpoints:
+      - name: "sparql"
+        operation: query
+        settings:
+          'arq:queryTimeout': "1000,10000"
+      - name: "data-update"
+        operation: update
+    database: "tdb2-db"
+
+databases:
+  - name: "tdb2-db"
+    dbtype: TDB2
+    location: "target/test-DB"
+
+connectors:
+  - fuseki-service: "/ds"
+    topic: "env:{ENV_KAFKA_TOPIC:RDF}"
+    bootstrap-servers: "localhost:9092"
+    state-file: "dDatabases/RDF.state"
+    group-id: "JenaFusekiKafka"
+    replay-topic: true
+    sync-topic: true
+    config:
+      key1: "value1"
+      key2: "value2"
+  - fuseki-service: "/ds2/data-update"
+    topic: "env:{ENV_KAFKA_TOPIC:RDF}"
+    bootstrap-servers: "localhost:9093"
+    state-file: "dDatabases/RDF.state"
+    group-id: "JenaFusekiKafka2"
+    replay-topic: true
+    sync-topic: true
+    config-file: "env:{KAFKA_CONFIG_FILE_PATH:}"
+
+

--- a/src/test/files/yaml/wrong/connector/config-connector-servicename-mismatch-3.yaml
+++ b/src/test/files/yaml/wrong/connector/config-connector-servicename-mismatch-3.yaml
@@ -1,0 +1,45 @@
+version: "1.0"
+server:
+  name: "Fuseki server simple"
+services:
+  - name: "ds"
+    endpoints:
+      - name: "sparql"
+        operation: query
+        settings:
+          'arq:queryTimeout': "1000,10000"
+      - name: "data-update"
+        operation: update
+    database:  "tdb2-db"
+  - name: "ds2"
+    endpoints:
+      - name: "sparql"
+        operation: query
+        settings:
+          'arq:queryTimeout': "1000,10000"
+      - name: "data-update"
+        operation: update
+    database: "tdb2-db"
+
+databases:
+  - name: "tdb2-db"
+    dbtype: TDB2
+    location: "target/test-DB"
+
+connectors:
+  - fuseki-service: "/ds"
+    topic: "env:{ENV_KAFKA_TOPIC:RDF}"
+    bootstrap-servers: "localhost:9092"
+    state-file: "dDatabases/RDF.state"
+    group-id: "JenaFusekiKafka"
+    replay-topic: true
+    sync-topic: true
+    config:
+      key: "value"
+  - fuseki-service: "/ds2/ds"
+    topic: "env:{ENV_KAFKA_TOPIC:RDF}"
+    bootstrap-servers: "localhost:9093"
+    state-file: "dDatabases/RDF.state"
+    group-id: "JenaFusekiKafka2"
+    replay-topic: true
+    sync-topic: true

--- a/src/test/files/yaml/wrong/connector/config-connector-servicename-mismatch-4.yaml
+++ b/src/test/files/yaml/wrong/connector/config-connector-servicename-mismatch-4.yaml
@@ -1,0 +1,45 @@
+version: "1.0"
+server:
+  name: "Fuseki server simple"
+services:
+  - name: "ds"
+    endpoints:
+      - name: "sparql"
+        operation: query
+        settings:
+          'arq:queryTimeout': "1000,10000"
+      - name: "data-update"
+        operation: update
+    database:  "tdb2-db"
+  - name: "ds2"
+    endpoints:
+      - name: "sparql"
+        operation: query
+        settings:
+          'arq:queryTimeout': "1000,10000"
+      - name: "data-update"
+        operation: update
+    database: "tdb2-db"
+
+databases:
+  - name: "tdb2-db"
+    dbtype: TDB2
+    location: "target/test-DB"
+
+connectors:
+  - fuseki-service: "/ds/sparql"
+    topic: "env:{ENV_KAFKA_TOPIC:RDF}"
+    bootstrap-servers: "localhost:9092"
+    state-file: "dDatabases/RDF.state"
+    group-id: "JenaFusekiKafka"
+    replay-topic: true
+    sync-topic: true
+    config:
+      key: "value"
+  - fuseki-service: "/ds2/nie"
+    topic: "env:{ENV_KAFKA_TOPIC:RDF}"
+    bootstrap-servers: "localhost:9093"
+    state-file: "dDatabases/RDF.state"
+    group-id: "JenaFusekiKafka2"
+    replay-topic: true
+    sync-topic: true

--- a/src/test/java/yamlconfig/TestYAMLConfigParser.java
+++ b/src/test/java/yamlconfig/TestYAMLConfigParser.java
@@ -755,6 +755,49 @@ public class TestYAMLConfigParser {
     }
 
     @Test
+    public void connectorsTest2() {
+        ConfigStruct configToCheck = new ConfigStruct();
+        Server serverToCheck = new Server("Fuseki server simple", emptyMap());
+        Map<String, String> prefixes = new HashMap<>();
+        List<Endpoint> endpoints1 = new ArrayList<>();
+        Map<String, String> settings1 = new HashMap<String, String>();
+        settings1.put("arq:queryTimeout", "1000,10000");
+        endpoints1.add(new Endpoint("sparql", "query",settings1));
+        endpoints1.add(new Endpoint("data-update", "update", emptyMap()));
+        Service service1 = new Service("ds", endpoints1, "tdb2-db");
+        Database database1 = new Database("tdb2-db", ConfigConstants.TDB2, "", "", "","", "", "", "target/test-DB", "", "false", "", "", "", "", "", emptyMap());
+        List<Endpoint> endpoints2 = new ArrayList<>();
+        Map<String, String> settings2 = new HashMap<String, String>();
+        settings2.put("arq:queryTimeout", "1000,10000");
+        endpoints2.add(new Endpoint("sparql", "query",settings2));
+        endpoints2.add(new Endpoint("data-update", "update", emptyMap()));
+        Service service2 = new Service("ds2", endpoints2, "tdb2-db");
+        configToCheck.setServer(serverToCheck);
+        Map<String, String> config1 = new HashMap<String, String>();
+        config1.put("key1", "value1");
+        config1.put("key2", "value2");
+        Connector connector1 = new Connector("/ds", "env:{ENV_KAFKA_TOPIC:RDF}", "localhost:9092", "dDatabases/RDF.state", "JenaFusekiKafka", "true", "true", config1, "");
+        Connector connector2 = new Connector("/ds2/data-update", "env:{ENV_KAFKA_TOPIC:RDF}", "localhost:9093", "dDatabases/RDF.state", "JenaFusekiKafka2", "true", "true", emptyMap(), "env:{KAFKA_CONFIG_FILE_PATH:}");
+        List<Service> servicesToCheck = new ArrayList<>();
+        servicesToCheck.add(service1);
+        servicesToCheck.add(service2);
+        configToCheck.setServices(servicesToCheck);
+        List<Database> databasesToCheck = new ArrayList<>();
+        databasesToCheck.add(database1);
+        configToCheck.setDatabases(databasesToCheck);
+        List<Connector> connectorsToCheck = new ArrayList<>();
+        connectorsToCheck.add(connector1);
+        connectorsToCheck.add(connector2);
+        configToCheck.setConnectors(connectorsToCheck);
+        configToCheck.setVersion("1.0");
+        configToCheck.setPrefixes(prefixes);
+        Map<String, Object> map = ycp.parseYAMLConfigToMap("src/test/files/yaml/correct/connector/config-multiple-connectors-2.yaml");
+        ConfigStruct config = ycp.mapToConfigStruct(map);
+        assertEquals(config.toString(), configToCheck.toString());
+    }
+
+
+    @Test
     public void missingFusekiServiceNameTest() {
         RuntimeException ex = assertThrows(RuntimeException.class,() -> {
             ycp.runYAMLParser("src/test/files/yaml/wrong/connector/config-connector-missing-service-name.yaml");
@@ -798,6 +841,22 @@ public class TestYAMLConfigParser {
     public void ServiceNameMismatchTest2() {
         RuntimeException ex = assertThrows(RuntimeException.class,() -> {
             ycp.runYAMLParser("src/test/files/yaml/wrong/connector/config-connector-servicename-mismatch-2.yaml");
+        });
+        assertEquals("java.lang.IllegalArgumentException: Mismatch between existing services and the destination services of the connectors.", ex.getMessage());
+    }
+
+    @Test
+    public void ServiceNameMismatchTest3() {
+        RuntimeException ex = assertThrows(RuntimeException.class,() -> {
+            ycp.runYAMLParser("src/test/files/yaml/wrong/connector/config-connector-servicename-mismatch-3.yaml");
+        });
+        assertEquals("java.lang.IllegalArgumentException: Mismatch between existing services and the destination services of the connectors.", ex.getMessage());
+    }
+
+    @Test
+    public void ServiceNameMismatchTest4() {
+        RuntimeException ex = assertThrows(RuntimeException.class,() -> {
+            ycp.runYAMLParser("src/test/files/yaml/wrong/connector/config-connector-servicename-mismatch-4.yaml");
         });
         assertEquals("java.lang.IllegalArgumentException: Mismatch between existing services and the destination services of the connectors.", ex.getMessage());
     }


### PR DESCRIPTION
Allow service names in connectors to be service + endpoint, like in the sys-int SCG config.