### PR TITLE
Updating RDF ABAC and merging multiple labels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <license.header.path>${project.basedir}</license.header.path>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Internal dependencies -->
-        <dependency.fuseki-kafka>2.3.2</dependency.fuseki-kafka>
-        <dependency.jena>5.6.0</dependency.jena>
+        <dependency.fuseki-kafka>3.0.4</dependency.fuseki-kafka>
+        <dependency.jena>6.1.0</dependency.jena>
         <dependency.rdf-abac>3.1.2</dependency.rdf-abac>
         <!-- External dependencies -->
         <dependency.log4j2>2.25.3</dependency.log4j2>
@@ -51,7 +51,7 @@
         <!-- Test dependencies -->
         <dependency.junit5>6.0.2</dependency.junit5>
         <dependency.junit5-platform>1.10.1</dependency.junit5-platform>
-        <dependency.smart-caches-core>0.34.0</dependency.smart-caches-core>
+        <dependency.smart-caches-core>0.40.2</dependency.smart-caches-core>
         <dependency.test-containers>1.21.4</dependency.test-containers>
         <!-- Plugins -->
         <plugin.central>0.10.0</plugin.central>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <!-- Internal dependencies -->
         <dependency.fuseki-kafka>2.3.2</dependency.fuseki-kafka>
         <dependency.jena>5.6.0</dependency.jena>
-        <dependency.rdf-abac>1.1.4</dependency.rdf-abac>
+        <dependency.rdf-abac>3.1.2</dependency.rdf-abac>
         <!-- External dependencies -->
         <dependency.log4j2>2.25.3</dependency.log4j2>
         <dependency.snake-yaml>2.5</dependency.snake-yaml>

--- a/src/main/files/abac/data-and-labels.trig
+++ b/src/main/files/abac/data-and-labels.trig
@@ -16,7 +16,7 @@ GRAPH authz:labels {
     [ authz:pattern ':s :p1 123'  ; authz:label "level-1" ] .
 
     ## Multiple labels.
-    [ authz:pattern ':s :p2 456'  ; authz:label "manager", "level-1" ] .
+    [ authz:pattern ':s :p2 456'  ; authz:label "manager && level-1" ] .
     [ authz:pattern ':s :p2 789'  ; authz:label "manager"  ] .
 
     [ authz:pattern ':s1 :p1 1234' ; authz:label "manager"  ] .

--- a/src/test/files/rdf/abac/abac/labels.ttl
+++ b/src/test/files/rdf/abac/abac/labels.ttl
@@ -4,7 +4,7 @@ PREFIX : <http://example/>
 
 [ authz:pattern ':s :p1 123'  ; authz:label "level-1" ] .
 
-[ authz:pattern ':s :p2 456'  ; authz:label "manager", "level-1" ] .
+[ authz:pattern ':s :p2 456'  ; authz:label "manager && level-1" ] .
 [ authz:pattern ':s :p2 789'  ; authz:label "manager"  ] .
 
 [ authz:pattern ':s1 :p1 1234' ; authz:label "manager"  ] .

--- a/src/test/files/rdf/abac/config-test-abac-2.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-2.ttl
@@ -16,6 +16,11 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
 :dataset-under  rdf:type  tdb2:DatasetTDB2;
         tdb2:location  "target/test-abac-DB" .
 
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .
+
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :abac-tdb2-db;
         fuseki:endpoint  [ fuseki:name       "upload";
@@ -23,8 +28,3 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
                          ];
         fuseki:endpoint  [ fuseki:operation  fuseki:query ];
         fuseki:name      "ds" .
-
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .

--- a/src/test/files/rdf/abac/config-test-abac-4.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-4.ttl
@@ -14,11 +14,6 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         authz:cache          false;
         authz:dataset        :dataset-under .
 
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .
-
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :abac-db;
         fuseki:endpoint  [ fuseki:name       "upload";
@@ -26,3 +21,8 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
                          ];
         fuseki:endpoint  [ fuseki:operation  fuseki:query ];
         fuseki:name      "ds" .
+
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .

--- a/src/test/files/rdf/abac/config-test-abac-5.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-5.ttl
@@ -6,6 +6,11 @@ PREFIX ja:     <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
 
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .
+
 :dataset-under  rdf:type  ja:MemoryDataset;
         ja:data   "src/main/files/abac/data-and-labels.trig" .
 
@@ -23,8 +28,3 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
                          ];
         fuseki:endpoint  [ fuseki:operation  fuseki:query ];
         fuseki:name      "ds" .
-
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .

--- a/src/test/files/rdf/abac/config-test-abac-labels-file.ttl
+++ b/src/test/files/rdf/abac/config-test-abac-labels-file.ttl
@@ -6,6 +6,11 @@ PREFIX ja:     <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
 
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 )
+] .
+
 :dataset-under  rdf:type  ja:MemoryDataset;
         ja:data   "src/main/files/abac/data-no-labels.trig" .
 
@@ -14,11 +19,6 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         authz:cache       false;
         authz:dataset     :dataset-under;
         authz:labels      <file:abac/labels.ttl> .
-
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 )
-] .
 
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :abac-db;

--- a/src/test/files/rdf/connector/config-connector-integration-test-1.ttl
+++ b/src/test/files/rdf/connector/config-connector-integration-test-1.ttl
@@ -6,11 +6,6 @@ PREFIX ja:     <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
 
-[ rdf:type         fuseki:Server;
-  fuseki:name      "Fuseki server simple";
-  fuseki:services  ( :service1 :service2 )
-] .
-
 :dataset2  rdf:type  ja:MemoryDataset .
 
 :service2  rdf:type      fuseki:Service;
@@ -33,6 +28,11 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         fk:topic              "RDF0" .
 
 :dataset  rdf:type  ja:MemoryDataset .
+
+[ rdf:type         fuseki:Server;
+  fuseki:name      "Fuseki server simple";
+  fuseki:services  ( :service1 :service2 )
+] .
 
 :service1  rdf:type      fuseki:Service;
         fuseki:dataset   :dataset;

--- a/src/test/java/io/telicent/jena/fuseki/config/yaml/TestIntegrationABAC.java
+++ b/src/test/java/io/telicent/jena/fuseki/config/yaml/TestIntegrationABAC.java
@@ -33,7 +33,7 @@ import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.exec.*;
 import org.apache.jena.sparql.exec.http.DSP;
 import org.apache.jena.sparql.exec.http.QueryExecHTTPBuilder;
-import org.apache.jena.sparql.resultset.ResultSetCompare;
+import org.apache.jena.sparql.resultset.RDFOutput;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb2.TDB2Factory;
 import org.junit.jupiter.api.AfterEach;
@@ -101,7 +101,7 @@ public class TestIntegrationABAC {
         actualResponseRSR = query(server, "u1"); // 3
         server.stop();
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -122,7 +122,7 @@ public class TestIntegrationABAC {
         actualResponseRSR = query(server, "u1"); // 3
         server.stop();
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -147,7 +147,7 @@ public class TestIntegrationABAC {
         actualResponseRSR = query(server, "u1"); // 3
         server.stop();
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -171,7 +171,7 @@ public class TestIntegrationABAC {
         load(server);
         actualResponseRSR = query(server, "u1"); // 3
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
         expectedRSR.rewindable().reset();
         actualResponseRSR.reset();
@@ -182,7 +182,7 @@ public class TestIntegrationABAC {
         RowSetRewindable modifiedResponseRSR = query(server, "u1");
         server.stop();
 
-        boolean stillEquals = ResultSetCompare.isomorphic(modifiedResponseRSR, actualResponseRSR);
+        boolean stillEquals = isomorphic(modifiedResponseRSR, actualResponseRSR);
         assertFalse(stillEquals);
     }
 
@@ -206,7 +206,7 @@ public class TestIntegrationABAC {
         load(server);
         actualResponseRSR = query(server, "u1"); // 3
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
         expectedRSR.rewindable().reset();
         actualResponseRSR.reset();
@@ -217,7 +217,7 @@ public class TestIntegrationABAC {
         RowSetRewindable modifiedResponseRSR = query(server, "u1");
         server.stop();
 
-        boolean stillEquals = ResultSetCompare.isomorphic(modifiedResponseRSR, actualResponseRSR);
+        boolean stillEquals = isomorphic(modifiedResponseRSR, actualResponseRSR);
         assertTrue(stillEquals);
     }
 
@@ -242,7 +242,7 @@ public class TestIntegrationABAC {
         actualResponseRSR = query(server, "u1"); // 3
         server.stop();
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -267,7 +267,7 @@ public class TestIntegrationABAC {
         actualResponseRSR = query(server, "u1"); // 3
         server.stop();
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -306,7 +306,7 @@ public class TestIntegrationABAC {
         actualResponseRSR = query(server, "u1"); // 3
         server.stop();
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -352,7 +352,7 @@ public class TestIntegrationABAC {
         QueryExec qExec = QueryExec.dataset(DatasetGraphFactory.create(comparisonModel.getGraph())).query(query).build();
         RowSetRewindable expectedRSRtdl = qExec.select().rewindable();
 
-        boolean equals = ResultSetCompare.isomorphic(expectedRSRtdl, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSRtdl, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -398,5 +398,11 @@ public class TestIntegrationABAC {
                 .fusekiModules(mods)
                 .parseConfigFile(config)
                 .build();
+    }
+
+    public static boolean isomorphic(RowSet rs1, RowSet rs2) {
+        Model m1 = RDFOutput.encodeAsModel(ResultSet.adapt(rs1));
+        Model m2 = RDFOutput.encodeAsModel(ResultSet.adapt(rs2));
+        return m1.isIsomorphicWith(m2);
     }
 }


### PR DESCRIPTION
This PR updates RDF ABAC to version 3.1.2 which no longer supports multiple security labels. Test data has therefore been updated to merge multiple label instances into a single label.